### PR TITLE
Simple benchmarker added.

### DIFF
--- a/laser_slam/CMakeLists.txt
+++ b/laser_slam/CMakeLists.txt
@@ -9,6 +9,7 @@ catkin_simple(ALL_DEPS_REQUIRED)
 cs_add_library(${PROJECT_NAME} 
   src/laser_track.cpp
   src/incremental_estimator.cpp
+  src/benchmarker.cpp
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)

--- a/laser_slam/include/laser_slam/benchmarker.hpp
+++ b/laser_slam/include/laser_slam/benchmarker.hpp
@@ -1,0 +1,118 @@
+#ifndef LASER_SLAM_BENCHMARKER_HPP_
+#define LASER_SLAM_BENCHMARKER_HPP_
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace laser_slam {
+
+/// TODO(Mattia): Move this to the preprocessor definitions:
+#define ENABLE_BENCHMARKING
+
+#ifdef ENABLE_BENCHMARKING
+/// \brief Measure the time elapsed from this line to the end of the scope.
+#define BENCHMARK_BLOCK(unique_name) \
+  laser_slam::ScopedTimer unique_name(#unique_name);
+/// \brief Start a timer called unique_name.
+#define BENCHMARK_START(unique_name) \
+  auto __start ## unique_name = laser_slam::Benchmarker::clock::now();
+/// \brief Stop the timer called unique_name and commit the results
+/// to the benchmarker.
+#define BENCHMARK_STOP(unique_name) \
+  laser_slam::Benchmarker::addMeasurement( \
+      #unique_name, \
+      __start ## unique_name, \
+      laser_slam::Benchmarker::clock::now());
+#else
+#define BENCHMARK_BLOCK(unique_name)
+#define BENCHMARK_START(unique_name)
+#define BENCHMARK_STOP(unique_name)
+#endif
+
+/// \brief Benchmark helper class. Allows collecting execution times
+/// of parts of the code and computing their statistics.
+/// \note This class is thread-safe.
+class Benchmarker {
+
+ public:
+  /// \brief The clock used for timing operations
+  typedef std::chrono::high_resolution_clock clock;
+
+  /// \brief Add a time measurement for a region of code with a specific name.
+  static void addMeasurement(
+      const std::string& name,
+      const std::chrono::time_point<clock>& start,
+      const std::chrono::time_point<clock>& end);
+
+  /// \brief Print the statistics to the specified file
+  static void saveStatistics(const std::string& file_name);
+
+  /// \brief Print the statistics to the logger
+  static void logStatistics();
+
+ private:
+  /// \brief Prevent static class from being instantiated.
+  Benchmarker();
+
+  /// \brief Helper class for collecting statistics over a series of measurements.
+  class MeasurementStatistics_ {
+
+   public:
+    /// \brief Add a measurement.
+    void addMeasurement(const double& value);
+
+    /// \brief Compute the mean of the measurements.
+    double getMean() const;
+
+    /// \brief Compute the standard deviation of the measurements.
+    double getStandardDeviation() const;
+
+   private:
+    /// \brief Sum of the measurements, needed for computing mean and standard deviations.
+    double sum_ { 0.0 };
+
+    /// \brief Sum of squares of the measurements, needed for computing the standard deviation.
+    double sum_of_squares_ { 0.0 };
+
+    /// \brief The number of measurements recorded.
+    uint64_t measurements_count_ { 0 };
+  };
+
+  /// \brief Mutex for synchronizing accesses to the benchmarker.
+  static std::mutex mutex_;
+
+  /// \brief Map containing all the measurements for each named region of code.
+  static std::unordered_map<std::string, MeasurementStatistics_> statistics_;
+};
+
+/// \brief A timer that measures the time elapsed between its creation
+/// and destruction. This is useful for timing whole functions or any
+/// scoped block of code. The measurement is automatically committed to
+/// the benchmarker.
+class ScopedTimer {
+
+ public:
+  /// \brief The clock used for timing operations
+  typedef std::chrono::high_resolution_clock clock;
+
+  /// \brief Default constructor. Starts the timer.
+  ScopedTimer(const std::string name);
+
+  /// \brief Destructor. Stops the timer and commit the result to the
+  /// benchmarker.
+  ~ScopedTimer();
+
+ private:
+  /// \brief The time point when the timer was started.
+  std::chrono::time_point<clock> start_;
+
+  /// \brief Name of the timed block.
+  std::string name_;
+};
+
+} // namespace laser_slam
+
+#endif /* LASER_SLAM_BENCHMARKER_HPP_ */

--- a/laser_slam/include/laser_slam/benchmarker.hpp
+++ b/laser_slam/include/laser_slam/benchmarker.hpp
@@ -18,14 +18,14 @@ namespace laser_slam {
   laser_slam::ScopedTimer unique_name(#unique_name);
 /// \brief Start a timer called unique_name.
 #define BENCHMARK_START(unique_name) \
-  auto __start ## unique_name = laser_slam::Benchmarker::clock::now();
+  auto __start ## unique_name = laser_slam::Benchmarker::Clock::now();
 /// \brief Stop the timer called unique_name and commit the results
 /// to the benchmarker.
 #define BENCHMARK_STOP(unique_name) \
   laser_slam::Benchmarker::addMeasurement( \
       #unique_name, \
       __start ## unique_name, \
-      laser_slam::Benchmarker::clock::now());
+      laser_slam::Benchmarker::Clock::now());
 #else
 #define BENCHMARK_BLOCK(unique_name)
 #define BENCHMARK_START(unique_name)
@@ -39,18 +39,18 @@ class Benchmarker {
 
  public:
   /// \brief The clock used for timing operations
-  typedef std::chrono::high_resolution_clock clock;
+  typedef std::chrono::high_resolution_clock Clock;
 
   /// \brief Add a time measurement for a region of code with a specific name.
   static void addMeasurement(
       const std::string& name,
-      const std::chrono::time_point<clock>& start,
-      const std::chrono::time_point<clock>& end);
+      const std::chrono::time_point<Clock>& start,
+      const std::chrono::time_point<Clock>& end);
 
-  /// \brief Print the statistics to the specified file
+  /// \brief Print the statistics to the specified file.
   static void saveStatistics(const std::string& file_name);
 
-  /// \brief Print the statistics to the logger
+  /// \brief Print the statistics to the logger.
   static void logStatistics();
 
  private:
@@ -95,19 +95,17 @@ class Benchmarker {
 class ScopedTimer {
 
  public:
-  /// \brief The clock used for timing operations
-  typedef std::chrono::high_resolution_clock clock;
 
   /// \brief Default constructor. Starts the timer.
-  ScopedTimer(const std::string name);
+  ScopedTimer(const std::string& name);
 
-  /// \brief Destructor. Stops the timer and commit the result to the
+  /// \brief Destructor. Stops the timer and commits the result to the
   /// benchmarker.
   ~ScopedTimer();
 
  private:
   /// \brief The time point when the timer was started.
-  std::chrono::time_point<clock> start_;
+  std::chrono::time_point<Benchmarker::Clock> start_;
 
   /// \brief Name of the timed block.
   std::string name_;

--- a/laser_slam/src/benchmarker.cpp
+++ b/laser_slam/src/benchmarker.cpp
@@ -1,4 +1,6 @@
 
+#include "laser_slam/benchmarker.hpp"
+
 #include <chrono>
 #include <cmath>
 #include <fstream>
@@ -11,14 +13,12 @@
 
 #include <glog/logging.h>
 
-#include "laser_slam/benchmarker.hpp"
-
 namespace laser_slam {
 
 void Benchmarker::addMeasurement(
     const std::string& name,
-    const std::chrono::time_point<clock>& start,
-    const std::chrono::time_point<clock>& end) {
+    const std::chrono::time_point<Clock>& start,
+    const std::chrono::time_point<Clock>& end) {
 
   constexpr double mus_to_ms = 1.0 / 1000.0;
   auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
@@ -34,7 +34,7 @@ void Benchmarker::addMeasurement(
 void Benchmarker::saveStatistics(const std::string& file_name) {
 
   std::ofstream out_file;
-  out_file.open (file_name);
+  out_file.open(file_name);
 
   if (out_file.is_open()) {
 
@@ -42,11 +42,11 @@ void Benchmarker::saveStatistics(const std::string& file_name) {
     out_file << " " << std::endl
         << ALIGN_MODIFIERS << "Name: " << "Mean (SD)" << std::endl;
 
-    for (auto& codeBlock : statistics_) {
+    for (const auto& code_block : statistics_) {
       out_file << " "
-          << ALIGN_MODIFIERS << (codeBlock.first + ": ")
-          << FLOAT_MODIFIERS << codeBlock.second.getMean() << "ms ("
-          << FLOAT_MODIFIERS << codeBlock.second.getStandardDeviation()
+          << ALIGN_MODIFIERS << (code_block.first + ": ")
+          << FLOAT_MODIFIERS << code_block.second.getMean() << "ms ("
+          << FLOAT_MODIFIERS << code_block.second.getStandardDeviation()
           << "ms)"  << std::endl;
     }
 
@@ -65,11 +65,11 @@ void Benchmarker::logStatistics() {
   LOG(INFO) << " "
       << ALIGN_MODIFIERS << "Name: " << "Mean (SD)";
 
-  for (auto& codeBlock : statistics_) {
+  for (const auto& code_block : statistics_) {
     LOG(INFO) << " "
-        << ALIGN_MODIFIERS << (codeBlock.first + ": ")
-        << FLOAT_MODIFIERS << codeBlock.second.getMean() << "ms ("
-        << FLOAT_MODIFIERS << codeBlock.second.getStandardDeviation() << "ms)";
+        << ALIGN_MODIFIERS << (code_block.first + ": ")
+        << FLOAT_MODIFIERS << code_block.second.getMean() << "ms ("
+        << FLOAT_MODIFIERS << code_block.second.getStandardDeviation() << "ms)";
   }
 
   LOG(INFO) << "";
@@ -96,12 +96,12 @@ double Benchmarker::MeasurementStatistics_::getStandardDeviation() const {
       pow(sum_ / static_cast<double>(measurements_count_), 2.0));
 }
 
-ScopedTimer::ScopedTimer(const std::string name)
+ScopedTimer::ScopedTimer(const std::string& name)
   : name_(name)
-  , start_(Benchmarker::clock::now()) { }
+  , start_(Benchmarker::Clock::now()) { }
 
 ScopedTimer::~ScopedTimer() {
-  Benchmarker::addMeasurement(name_, start_, Benchmarker::clock::now());
+  Benchmarker::addMeasurement(name_, start_, Benchmarker::Clock::now());
 }
 
 }

--- a/laser_slam/src/benchmarker.cpp
+++ b/laser_slam/src/benchmarker.cpp
@@ -1,0 +1,107 @@
+
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <glog/logging.h>
+
+#include "laser_slam/benchmarker.hpp"
+
+namespace laser_slam {
+
+void Benchmarker::addMeasurement(
+    const std::string& name,
+    const std::chrono::time_point<clock>& start,
+    const std::chrono::time_point<clock>& end) {
+
+  constexpr double mus_to_ms = 1.0 / 1000.0;
+  auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+  double milliseconds = static_cast<double>(microseconds) * mus_to_ms;
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  statistics_[name].addMeasurement(milliseconds);
+}
+
+#define ALIGN_MODIFIERS std::setw(40) << std::setfill(' ') << std::left
+#define FLOAT_MODIFIERS std::fixed << std::setprecision(2)
+
+void Benchmarker::saveStatistics(const std::string& file_name) {
+
+  std::ofstream out_file;
+  out_file.open (file_name);
+
+  if (out_file.is_open()) {
+
+    out_file << "Benchmark results:" << std::endl;
+    out_file << " " << std::endl
+        << ALIGN_MODIFIERS << "Name: " << "Mean (SD)" << std::endl;
+
+    for (auto& codeBlock : statistics_) {
+      out_file << " "
+          << ALIGN_MODIFIERS << (codeBlock.first + ": ")
+          << FLOAT_MODIFIERS << codeBlock.second.getMean() << "ms ("
+          << FLOAT_MODIFIERS << codeBlock.second.getStandardDeviation()
+          << "ms)"  << std::endl;
+    }
+
+    out_file.close();
+    LOG(INFO) << "Benchmark results saved to " << file_name;
+  }
+  else {
+    LOG(INFO) << "Failed to save benchmark results.";
+  }
+}
+
+void Benchmarker::logStatistics() {
+
+  LOG(INFO) << "";
+  LOG(INFO) << "Benchmark results:";
+  LOG(INFO) << " "
+      << ALIGN_MODIFIERS << "Name: " << "Mean (SD)";
+
+  for (auto& codeBlock : statistics_) {
+    LOG(INFO) << " "
+        << ALIGN_MODIFIERS << (codeBlock.first + ": ")
+        << FLOAT_MODIFIERS << codeBlock.second.getMean() << "ms ("
+        << FLOAT_MODIFIERS << codeBlock.second.getStandardDeviation() << "ms)";
+  }
+
+  LOG(INFO) << "";
+}
+
+Benchmarker::Benchmarker() { }
+
+std::mutex Benchmarker::mutex_;
+std::unordered_map<std::string, Benchmarker::MeasurementStatistics_> Benchmarker::statistics_;
+
+void Benchmarker::MeasurementStatistics_::addMeasurement(const double& value) {
+  sum_ += value;
+  sum_of_squares_ += value * value;
+  measurements_count_++;
+}
+
+double Benchmarker::MeasurementStatistics_::getMean() const {
+  return sum_ / static_cast<double>(measurements_count_);
+}
+
+double Benchmarker::MeasurementStatistics_::getStandardDeviation() const {
+  return sqrt(
+      sum_of_squares_ / static_cast<double>(measurements_count_) -
+      pow(sum_ / static_cast<double>(measurements_count_), 2.0));
+}
+
+ScopedTimer::ScopedTimer(const std::string name)
+  : name_(name)
+  , start_(Benchmarker::clock::now()) { }
+
+ScopedTimer::~ScopedTimer() {
+  Benchmarker::addMeasurement(name_, start_, Benchmarker::clock::now());
+}
+
+}


### PR DESCRIPTION
Simple benchmarker for measuring the execution time:
- Between any two code lines, with BENCHMARK_START(name); BENCHMARK_STOP(name);
- Of a whole scope (e.g. a function), with BENCHMARK_BLOCK(name)

Mean and standard deviation are computed for multiple measurements with the same name.