### PR TITLE
Improved benchmarker

### DIFF
--- a/laser_slam/include/laser_slam/benchmarker.hpp
+++ b/laser_slam/include/laser_slam/benchmarker.hpp
@@ -28,7 +28,7 @@ namespace laser_slam {
   laser_slam::Benchmarker::stopMeasurement(topic_name, true);
 /// \brief Records a value in the \c topic_name topic. Only values of type \c double are supported.
 #define BENCHMARK_RECORD_VALUE(topic_name, value) \
-    laser_slam::Benchmarker::addValue(topic_name, value);
+    laser_slam::Benchmarker::addValue(topic_name, static_cast<double>(value));
 /// \brief Reset the topics with name starting with \c topic_prefix.
 #define BENCHMARK_RESET(topic_prefix) laser_slam::Benchmarker::resetTopic(topic_prefix);
 /// \brief Reset all topics.
@@ -44,9 +44,14 @@ namespace laser_slam {
 #define BENCHMARK_RESET_ALL()
 #endif
 
+/// \brief Parameters of the benchmarker.
 struct BenchmarkerParams {
+  /// \brief If true, the benchmarker will collect only statistics, without storing the actual
+  /// measurements.
   bool save_statistics_only;
+  /// \brief If true, every collected measurement or value will printed to the logger.
   bool enable_live_output;
+  /// \brief Path where the results will be saved.
   std::string results_directory;
 };
 
@@ -70,92 +75,109 @@ class Benchmarker {
   static void notifyNewStepStart();
 
   /// \brief Starts a measurement for the \c topic_name topic.
+  /// \param topic_name Name of the topic to which the measurement belongs.
   static void startMeasurement(const std::string& topic_name);
 
   /// \brief Stops a measurement for the \c topic_name topic.
+  /// \param topic_name Name of the topic to which the measurement belongs.
+  /// \param ignore_measurement If true, the timer will be stopped but the result is ignored.
   static void stopMeasurement(const std::string& topic_name, bool ignore_measurement = false);
 
   /// \brief Add a measurement for the \c topic_name topic.
-  static void addMeasurement(const std::string& topic_name, const TimePoint& start,
-                             const TimePoint& end);
+  /// \param topic_name Name of the topic to which the measurement belongs.
+  /// \param start The timestamp representing the start of the measurement.
+  /// \param start The timestamp representing the end of the measurement.
+  static void addMeasurement(const std::string& topic_name, const TimePoint start,
+                             const TimePoint end);
 
   /// \brief Add a value for the \c topic_name topic.
+  /// \param topic_name Name of the topic to which the value belongs.
+  /// \param value The value that must be added.
   static void addValue(const std::string& topic_name, double value);
 
   /// \brief Reset all collected data for all the topics with the given prefix. If \e topic_prefix
-  /// is an empty string, all data will be reset.
+  /// is an empty string, all data will be reset
+  /// \param topic_prefix Prefix for the names of the topics that must be reset.
   static void resetTopic(const std::string& topic_prefix);
 
   /// \brief Save the recorded data for all the topics.
   static void saveData();
 
-  /// \brief Print the statistics to the logger.
-  static void logStatistics();
+  /// \brief Print the statistics to the specified string.
+  /// \param stream The destination stream.
+  static void logStatistics(std::ostream& stream);
 
   /// \brief Set the parameters of the benchmarker.
   /// \param parameters The new parameters for the benchmarker.
-  static inline void setParameters(const BenchmarkerParams& parameters) {
-    params_ = parameters;
-  }
+  static inline void setParameters(const BenchmarkerParams& parameters) { params_ = parameters; }
 
   /// \brief Get the parameters of the benchmarker.
   /// \return The parameters of the benchmarker.
-  static inline const BenchmarkerParams& getParameters() {
-    return params_;
-  }
+  static inline const BenchmarkerParams& getParameters() { return params_; }
 
  private:
-  /// \brief Helper class for collecting data and statistics about values.
+  // Represents a value and information about the step from which it was collected.
+  struct ValueEntry {
+    ValueEntry(size_t step_id, const TimePoint timestamp, double value)
+      : step_id(step_id), timestamp(timestamp), value(value) {
+    }
+    size_t step_id;
+    TimePoint timestamp;
+    double value;
+  };
+
+  // Helper class for collecting data and statistics about values.
   class ValueTopic {
 
    public:
-    /// \brief Adds a value.
-    void addValue(const TimePoint& timestamp, double value);
+    // Adds a value.
+    void addValue(size_t step_id, const TimePoint timestamp, double value);
 
-    /// \brief Computes the mean of the measurements.
+    // Computes the mean of the measurements.
     double getMean() const;
 
-    /// \brief Computes the standard deviation of the values.
+    // Computes the standard deviation of the values.
     double getStandardDeviation() const;
 
-    /// \brief Gets a reference to the stored data.
-    inline const std::vector<std::pair<TimePoint, double>>& getValues() const {
-      return values_;
-    }
+    // Gets a reference to the stored data.
+    inline const std::vector<ValueEntry>& getValues() const { return values_; }
 
    private:
-    /// \brief Sum of the values, needed for computing mean and standard deviations.
+    // Sum of the values, needed for computing mean and standard deviations.
     double sum_ = 0.0;
 
-    /// \brief Sum of squares of the values, needed for computing the standard deviation.
+    // Sum of squares of the values, needed for computing the standard deviation.
     double sum_of_squares_ = 0.0;
 
-    /// \brief The number of values recorded.
+    // The number of values recorded.
     uint64_t values_count_ = 0;
 
-    /// \brief The values_ collected.
-    std::vector<std::pair<TimePoint, double>> values_;
+    // The collected values.
+    std::vector<ValueEntry> values_;
   };
 
   // Helper functions.
   static std::string setupAndGetResultsRootDirectory();
   static TimePoint getFirstValueTimepoint();
-  static double durationToMilliseconds(const Duration& duration);
+  static double durationToMilliseconds(Duration duration);
 
   // Mutexes for synchronizing accesses to the benchmarker.
   static std::mutex value_topics_mutex_;
   static std::mutex started_measurements_mutex_;
 
-  /// \brief Map containing the values sorted in alphabetical order.
+  // Map containing the values sorted in alphabetical order.
   static std::map<std::string, ValueTopic> value_topics_;
 
-  /// \brief Starting time points of the measurements currently in progress.
+  // Starting time points of the measurements currently in progress.
   static std::unordered_map<std::string, TimePoint> started_mesurements_;
 
-  /// \brief Timestamp of the step being currently benchmarked.
+  // Timestamp of the step being currently benchmarked.
   static TimePoint current_timestamp_;
 
-  /// \brief Parameters of the benchmarker.
+  // ID of the step being currently benchmarked.
+  static size_t current_step_id_;
+
+  // Parameters of the benchmarker.
   static BenchmarkerParams params_;
 };
 
@@ -166,6 +188,7 @@ class ScopedTimer {
 
  public:
   /// \brief Default constructor. Starts the timer.
+  /// \param topic_name Name of the topic to which the measurement belongs.
   ScopedTimer(const std::string& topic_name)
    : topic_name_(topic_name)
    , start_(Benchmarker::Clock::now()) {
@@ -175,10 +198,10 @@ class ScopedTimer {
   ~ScopedTimer();
 
  private:
-  /// \brief Name of the timed block.
+  // Name of the timed block.
   const std::string topic_name_;
 
-  /// \brief The time point when the timer was started.
+  // The time point when the timer was started.
   const std::chrono::time_point<Benchmarker::Clock> start_;
 };
 

--- a/laser_slam/include/laser_slam/benchmarker.hpp
+++ b/laser_slam/include/laser_slam/benchmarker.hpp
@@ -86,7 +86,7 @@ class Benchmarker {
   /// \brief Add a measurement for the \c topic_name topic.
   /// \param topic_name Name of the topic to which the measurement belongs.
   /// \param start The timestamp representing the start of the measurement.
-  /// \param start The timestamp representing the end of the measurement.
+  /// \param end The timestamp representing the end of the measurement.
   static void addMeasurement(const std::string& topic_name, const TimePoint start,
                              const TimePoint end);
 
@@ -150,7 +150,7 @@ class Benchmarker {
     double sum_of_squares_ = 0.0;
 
     // The number of values recorded.
-    uint64_t values_count_ = 0;
+    uint64_t values_count_ = 0u;
 
     // The collected values.
     std::vector<ValueEntry> values_;
@@ -190,8 +190,7 @@ class ScopedTimer {
   /// \brief Default constructor. Starts the timer.
   /// \param topic_name Name of the topic to which the measurement belongs.
   ScopedTimer(const std::string& topic_name)
-   : topic_name_(topic_name)
-   , start_(Benchmarker::Clock::now()) {
+   : topic_name_(topic_name), start_(Benchmarker::Clock::now()) {
   }
 
   /// \brief Destructor. Stops the timer and commits the result to the benchmarker.

--- a/laser_slam/include/laser_slam/benchmarker.hpp
+++ b/laser_slam/include/laser_slam/benchmarker.hpp
@@ -2,128 +2,170 @@
 #define LASER_SLAM_BENCHMARKER_HPP_
 
 #include <chrono>
+#include <map>
 #include <mutex>
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 namespace laser_slam {
 
 // In order to use the benchmarker define the following macro in your project.
 // #define BENCHMARK_ENABLE
-// Enable live output of the measured timings (optional).
-// #define BENCHMARK_ENABLE_LIVE_OUTPUT
 
 #ifdef BENCHMARK_ENABLE
-/// \brief Measure the time elapsed from this line to the end of the scope.
-#define BENCHMARK_BLOCK(unique_name) \
-  laser_slam::ScopedTimer unique_name(#unique_name);
-/// \brief Start a timer called unique_name.
-#define BENCHMARK_START(unique_name) \
-  auto __start ## unique_name = laser_slam::Benchmarker::Clock::now();
-/// \brief Stop the timer called unique_name and commit the results
-/// to the benchmarker.
-#define BENCHMARK_STOP(unique_name) \
-  laser_slam::Benchmarker::addMeasurement( \
-      #unique_name, \
-      __start ## unique_name, \
-      laser_slam::Benchmarker::Clock::now());
-/// \brief Reset the statistics for a specific name.
-#define BENCHMARK_RESET(unique_name) \
-  laser_slam::Benchmarker::resetStatistics( #unique_name );
-/// \brief Reset all statistics.
-#define BENCHMARK_RESET_ALL() \
-  laser_slam::Benchmarker::resetStatistics("");
+/// \brief Measure the time elapsed from this line to the end of the scope and record it to the
+/// \c topic_name topic.
+#define BENCHMARK_BLOCK(topic_name) laser_slam::ScopedTimer __timer_ ## __LINE__(topic_name);
+/// \brief Starts a measurement for the \c topic_name topic.
+#define BENCHMARK_START(topic_name) laser_slam::Benchmarker::startMeasurement(topic_name);
+/// \brief Stops a measurement for the \c topic_name topic.
+#define BENCHMARK_STOP(topic_name) laser_slam::Benchmarker::stopMeasurement(topic_name);
+/// \brief Records a value in the \c topic_name topic. Only values of type \c double are supported.
+#define BENCHMARK_RECORD_VALUE(topic_name, value) \
+    laser_slam::Benchmarker::addValue(topic_name, value);
+/// \brief Reset the topics with name starting with \c topic_prefix.
+#define BENCHMARK_RESET(topic_prefix) laser_slam::Benchmarker::resetTopic(topic_prefix);
+/// \brief Reset all topics.
+#define BENCHMARK_RESET_ALL() laser_slam::Benchmarker::resetTopic("");
 #else
-#define BENCHMARK_BLOCK(unique_name)
-#define BENCHMARK_START(unique_name)
-#define BENCHMARK_STOP(unique_name)
-#define BENCHMARK_RESET(unique_name)
+#define BENCHMARK_BLOCK(topic_name)
+#define BENCHMARK_START(topic_name)
+#define BENCHMARK_STOP(topic_name)
+#define BENCHMARK_RECORD_VALUE(topic_name, value)
+#define BENCHMARK_RESET(topic_prefix)
 #define BENCHMARK_RESET_ALL()
 #endif
 
-/// \brief Benchmark helper class. Allows collecting execution times
-/// of parts of the code and computing their statistics.
-/// \note This class is thread-safe.
+struct BenchmarkerParams {
+  bool save_statistics_only;
+  bool enable_live_output;
+  std::string results_directory;
+};
+
+/// \brief Benchmark helper class. Allows collecting data and statistics about execution times and
+/// metrics (values).
+/// \remark This class is thread-safe, but simultaneously collecting measurements for the same
+/// topic from multiple threads is not supported.
 class Benchmarker {
 
  public:
-  /// \brief The clock used for timing operations
+  /// \brief The clock used by the benchmarker.
   typedef std::chrono::high_resolution_clock Clock;
+  typedef Clock::time_point TimePoint;
+  typedef Clock::duration Duration;
 
-  /// \brief Add a time measurement for a region of code with a specific name.
-  static void addMeasurement(
-      const std::string& name,
-      const std::chrono::time_point<Clock>& start,
-      const std::chrono::time_point<Clock>& end);
+  /// \brief Prevent static class from being instantiated.
+  Benchmarker() = delete;
 
-  /// \brief Reset the statistics for the specified name. If \e name is an
-  /// empty string, all statistics will be reset.
-  static void resetStatistics(const std::string& name);
+  /// \brief Starts a measurement for the \c topic_name topic.
+  static void startMeasurement(const std::string& topic_name);
 
-  /// \brief Print the statistics to the specified file.
-  static void saveStatistics(const std::string& file_name);
+  /// \brief Stops a measurement for the \c topic_name topic.
+  static void stopMeasurement(const std::string& topic_name);
+
+  /// \brief Add a measurement for the \c topic_name topic.
+  static void addMeasurement(const std::string& topic_name, const TimePoint& start,
+                             const TimePoint& end);
+
+  /// \brief Add a value for the \c topic_name topic.
+  static void addValue(const std::string& topic_name, double value);
+
+  /// \brief Reset all collected data for all the topics with the given prefix. If \e topic_prefix
+  /// is an empty string, all data will be reset.
+  static void resetTopic(const std::string& topic_prefix);
+
+  /// \brief Save the recorded data for all the topics.
+  static void saveData();
 
   /// \brief Print the statistics to the logger.
   static void logStatistics();
 
- private:
-  /// \brief Prevent static class from being instantiated.
-  Benchmarker();
+  /// \brief Set the parameters of the benchmarker.
+  /// \param parameters The new parameters for the benchmarker.
+  static inline void setParameters(const BenchmarkerParams& parameters) {
+    params_ = parameters;
+  }
 
-  /// \brief Helper class for collecting statistics over a series of measurements.
-  class MeasurementStatistics_ {
+  /// \brief Get the parameters of the benchmarker.
+  /// \return The parameters of the benchmarker.
+  static inline const BenchmarkerParams& getParameters() {
+    return params_;
+  }
+
+ private:
+  /// \brief Helper class for collecting data and statistics about values.
+  class ValueTopic {
 
    public:
-    /// \brief Add a measurement.
-    void addMeasurement(const double& value);
+    /// \brief Adds a value.
+    void addValue(const TimePoint& timestamp, double value);
 
-    /// \brief Compute the mean of the measurements.
+    /// \brief Computes the mean of the measurements.
     double getMean() const;
 
-    /// \brief Compute the standard deviation of the measurements.
+    /// \brief Computes the standard deviation of the values.
     double getStandardDeviation() const;
 
+    /// \brief Gets a reference to the stored data.
+    inline const std::vector<std::pair<TimePoint, double>>& getValues() const {
+      return values_;
+    }
+
    private:
-    /// \brief Sum of the measurements, needed for computing mean and standard deviations.
-    double sum_ { 0.0 };
+    /// \brief Sum of the values, needed for computing mean and standard deviations.
+    double sum_ = 0.0;
 
-    /// \brief Sum of squares of the measurements, needed for computing the standard deviation.
-    double sum_of_squares_ { 0.0 };
+    /// \brief Sum of squares of the values, needed for computing the standard deviation.
+    double sum_of_squares_ = 0.0;
 
-    /// \brief The number of measurements recorded.
-    uint64_t measurements_count_ { 0 };
+    /// \brief The number of values recorded.
+    uint64_t values_count_ = 0;
+
+    /// \brief The values_ collected.
+    std::vector<std::pair<TimePoint, double>> values_;
   };
 
-  /// \brief Mutex for synchronizing accesses to the benchmarker.
-  static std::mutex mutex_;
+  // Helper functions.
+  static std::string setupAndGetResultsRootDirectory();
+  static TimePoint getFirstValueTimepoint();
+  static double durationToMilliseconds(const Duration& duration);
 
-  /// \brief Map containing all the measurements for each named region of code.
-  /// Measurements are sorted in alphabetical order.
-  static std::map<std::string, MeasurementStatistics_> statistics_;
+  // Mutexes for synchronizing accesses to the benchmarker.
+  static std::mutex value_topics_mutex_;
+  static std::mutex started_measurements_mutex_;
+
+  /// \brief Map containing the values sorted in alphabetical order.
+  static std::map<std::string, ValueTopic> value_topics_;
+
+  /// \brief Starting time points of the measurements currently in progress.
+  static std::unordered_map<std::string, TimePoint> started_mesurements_;
+
+  /// \brief Parameters of the benchmarker.
+  static BenchmarkerParams params_;
 };
 
-/// \brief A timer that measures the time elapsed between its creation
-/// and destruction. This is useful for timing whole functions or any
-/// scoped block of code. The measurement is automatically committed to
-/// the benchmarker.
+/// \brief A timer that measures the time elapsed between its creation and destruction. This is
+/// useful for timing whole functions or any scoped block of code. The measurement is automatically
+/// committed to the benchmarker.
 class ScopedTimer {
 
  public:
-
   /// \brief Default constructor. Starts the timer.
-  ScopedTimer(const std::string& name);
+  ScopedTimer(const std::string& topic_name)
+   : topic_name_(topic_name)
+   , start_(Benchmarker::Clock::now()) {
+  }
 
-  /// \brief Destructor. Stops the timer and commits the result to the
-  /// benchmarker.
+  /// \brief Destructor. Stops the timer and commits the result to the benchmarker.
   ~ScopedTimer();
 
  private:
-  /// \brief The time point when the timer was started.
-  std::chrono::time_point<Benchmarker::Clock> start_;
-
   /// \brief Name of the timed block.
-  std::string name_;
+  const std::string topic_name_;
+
+  /// \brief The time point when the timer was started.
+  const std::chrono::time_point<Benchmarker::Clock> start_;
 };
 
 } // namespace laser_slam

--- a/laser_slam/src/benchmarker.cpp
+++ b/laser_slam/src/benchmarker.cpp
@@ -73,9 +73,13 @@ void Benchmarker::addValue(const std::string& topic_name, const double value) {
 
 void Benchmarker::resetTopic(const std::string& topic_prefix) {
   std::lock_guard<std::mutex> lock(value_topics_mutex_);
-  for (auto& topic : value_topics_) {
-    if (topic.first.find(topic_prefix) == 0) {
-      topic.second = ValueTopic();
+  for (auto topic_it = value_topics_.begin(); topic_it != value_topics_.end();) {
+    // Delete topics that have the specified prefix.
+    if (topic_it->first.find("Times." + topic_prefix) == 0 ||
+        topic_it->first.find("Values." + topic_prefix) == 0) {
+      value_topics_.erase(topic_it++);
+    } else {
+      ++topic_it;
     }
   }
 }

--- a/laser_slam/src/benchmarker.cpp
+++ b/laser_slam/src/benchmarker.cpp
@@ -82,6 +82,11 @@ void Benchmarker::resetTopic(const std::string& topic_prefix) {
       ++topic_it;
     }
   }
+
+  if (topic_prefix == "") {
+    current_timestamp_ = Clock::now();
+    current_step_id_ = 0u;
+  }
 }
 
 void Benchmarker::saveData() {

--- a/laser_slam_ros/include/laser_slam_ros/common.hpp
+++ b/laser_slam_ros/include/laser_slam_ros/common.hpp
@@ -1,8 +1,8 @@
 #ifndef LASER_SLAM_ROS_COMMON_HPP_
 #define LASER_SLAM_ROS_COMMON_HPP_
 
-#include <laser_slam/parameters.hpp>
 #include <laser_slam/benchmarker.hpp>
+#include <laser_slam/parameters.hpp>
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>

--- a/laser_slam_ros/include/laser_slam_ros/common.hpp
+++ b/laser_slam_ros/include/laser_slam_ros/common.hpp
@@ -2,6 +2,7 @@
 #define LASER_SLAM_ROS_COMMON_HPP_
 
 #include <laser_slam/parameters.hpp>
+#include <laser_slam/benchmarker.hpp>
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -139,6 +140,18 @@ static laser_slam::EstimatorParams getOnlineEstimatorParams(const ros::NodeHandl
   nh.getParam(ns + "/loop_closures_sub_maps_radius", params.loop_closures_sub_maps_radius);
 
   params.laser_track_params = getLaserTrackParams(nh, ns);
+
+  return params;
+}
+
+static laser_slam::BenchmarkerParams getBenchmarkerParams(const ros::NodeHandle& nh,
+                                                          const std::string& prefix) {
+  laser_slam::BenchmarkerParams params;
+  const std::string ns = prefix + "/Benchmarker";
+
+  nh.getParam(ns + "/save_statistics_only", params.save_statistics_only);
+  nh.getParam(ns + "/enable_live_output", params.enable_live_output);
+  nh.getParam(ns + "/results_directory", params.results_directory);
 
   return params;
 }


### PR DESCRIPTION
@rdube this adds the functionalities that were missing in the first version.
- All measured values can be optionally stored for plotting.
- Beside timing measurements, also values can be stored, e.g. number of voxels created, number of matches, loop closure event, ...
- Timings and values are organized in hierarchical topics, making it easier to visually understand the statistics and to plot the factors contributing to a specific part of the code.
- Every collected measurement/value is associated with the timestamp and the ID of the update step, making easy to associate value for plots like segmentation time vs. number of new voxels.

Should be useful for you as well for papers/presentations, feel free to ask more details about how to use it :)