### PR TITLE
Update the strategy for handling priors on trajectory

### DIFF
--- a/laser_slam/include/laser_slam/incremental_estimator.hpp
+++ b/laser_slam/include/laser_slam/incremental_estimator.hpp
@@ -52,11 +52,6 @@ class IncrementalEstimator {
                               const gtsam::Values& new_values,
                               const unsigned int worker_id);
 
-  void getEstimationTimes(std::map<laser_slam::Time, double>* estimation_times) const {
-    CHECK_NOTNULL(estimation_times);
-    *estimation_times = estimation_times_;
-  }
-
  private:
   unsigned int n_laser_slam_workers_;
 
@@ -82,9 +77,6 @@ class IncrementalEstimator {
   std::vector<unsigned int> worker_ids_with_removed_prior_;
 
   std::unordered_map<unsigned int, unsigned int> if_first_then_remove_second_;
-
-  std::map<laser_slam::Time, double> estimation_times_;
-
 
   // Parameters.
   EstimatorParams params_;

--- a/laser_slam/include/laser_slam/incremental_estimator.hpp
+++ b/laser_slam/include/laser_slam/incremental_estimator.hpp
@@ -72,11 +72,9 @@ class IncrementalEstimator {
   gtsam::noiseModel::Base::shared_ptr loop_closure_noise_model_;
   gtsam::noiseModel::Base::shared_ptr first_association_noise_model_;
 
-
   std::unordered_map<unsigned int, size_t> factor_indices_to_remove_;
-  std::vector<unsigned int> worker_ids_with_removed_prior_;
-
-  std::unordered_map<unsigned int, unsigned int> if_first_then_remove_second_;
+  
+  std::vector<std::vector<unsigned int> > linked_workers_;
 
   // Parameters.
   EstimatorParams params_;

--- a/laser_slam/src/incremental_estimator.cpp
+++ b/laser_slam/src/incremental_estimator.cpp
@@ -152,7 +152,6 @@ Values IncrementalEstimator::estimate(const gtsam::NonlinearFactorGraph& new_fac
                                       const gtsam::Values& new_values,
                                       laser_slam::Time timestamp_ns) {
   std::lock_guard<std::recursive_mutex> lock(full_class_mutex_);
-  Clock clock;
   // Update and force relinearization.
   isam2_.update(new_factors, new_values).print();
   // TODO Investigate why these two subsequent update calls are needed.
@@ -160,10 +159,6 @@ Values IncrementalEstimator::estimate(const gtsam::NonlinearFactorGraph& new_fac
   isam2_.update();
 
   Values result(isam2_.calculateEstimate());
-
-  clock.takeTime();
-  LOG(INFO) << "Took " << clock.getRealTime() << "ms to estimate the trajectory.";
-  estimation_times_.emplace(timestamp_ns, clock.getRealTime());
   return result;
 }
 
@@ -175,7 +170,6 @@ Values IncrementalEstimator::estimateAndRemove(
     laser_slam::Time timestamp_ns) {
   std::lock_guard<std::recursive_mutex> lock(full_class_mutex_);
 
-  Clock clock;
   CHECK_EQ(affected_worker_ids.size(), 2u);
   gtsam::NonlinearFactorGraph new_factors_to_add = new_factors;
   // Find and update the factor indices to remove.
@@ -230,10 +224,6 @@ Values IncrementalEstimator::estimateAndRemove(
   isam2_.update();
 
   Values result(isam2_.calculateEstimate());
-
-  clock.takeTime();
-  LOG(INFO) << "Took " << clock.getRealTime() << "ms to estimate the trajectory.";
-  estimation_times_.emplace(timestamp_ns, clock.getRealTime());
   return result;
 }
 

--- a/laser_slam/src/incremental_estimator.cpp
+++ b/laser_slam/src/incremental_estimator.cpp
@@ -171,7 +171,7 @@ Values IncrementalEstimator::estimateAndRemove(
   std::lock_guard<std::recursive_mutex> lock(full_class_mutex_);
 
   CHECK_EQ(affected_worker_ids.size(), 2u);
-  gtsam::NonlinearFactorGraph new_factors_to_add = new_factors;
+  
   // Find and update the factor indices to remove.
   std::vector<size_t> factor_indices_to_remove;
   
@@ -249,7 +249,12 @@ Values IncrementalEstimator::estimateAndRemove(
       }
   }
   LOG(INFO) << "linked_workers after " << linked_workers_print;
-
+  gtsam::NonlinearFactorGraph new_factors_to_add;
+  if (!factor_indices_to_remove.empty()) {
+    new_factors_to_add = new_associations_factors;
+  } else {
+    new_factors_to_add = new_factors;
+  }
   isam2_.update(new_factors_to_add, new_values, factor_indices_to_remove).print();
 
   // TODO Investigate why these two subsequent update calls are needed.

--- a/laser_slam/src/incremental_estimator.cpp
+++ b/laser_slam/src/incremental_estimator.cpp
@@ -174,48 +174,81 @@ Values IncrementalEstimator::estimateAndRemove(
   gtsam::NonlinearFactorGraph new_factors_to_add = new_factors;
   // Find and update the factor indices to remove.
   std::vector<size_t> factor_indices_to_remove;
-  if (affected_worker_ids.at(0u) != affected_worker_ids.at(1u)) {
-    // Remove the prior of the worker with the largest ID if not already removed.
-    const unsigned int max_id = std::max(affected_worker_ids.at(0u),
-                                         affected_worker_ids.at(1u));
-
-    const unsigned int min_id = std::min(affected_worker_ids.at(0u),
-                                         affected_worker_ids.at(1u));
-
-    unsigned int worker_id_to_remove = max_id;
-
-    if (min_id != 0u) {
-      if_first_then_remove_second_.emplace(worker_id_to_remove,
-                                           min_id);
-    }
-
-    if (std::find(worker_ids_with_removed_prior_.begin(),
-                  worker_ids_with_removed_prior_.end(), worker_id_to_remove) !=
-                      worker_ids_with_removed_prior_.end()) {
-      worker_id_to_remove = std::min(affected_worker_ids.at(0u),
-                                     affected_worker_ids.at(1u));
-
-    }
-
-    if (factor_indices_to_remove_.count(worker_id_to_remove) != 1u) {
-      if (min_id == 0u) {
-        if (if_first_then_remove_second_.find(max_id) !=
-            if_first_then_remove_second_.end()) {
-          worker_id_to_remove = if_first_then_remove_second_.at(max_id);
-        }
+  
+  std::string linked_workers_print = "";
+  for (size_t i = 0u; i < linked_workers_.size(); ++i) {
+      linked_workers_print += "Group " + std::to_string(i) + ": ";
+      for (const auto& worker_id : linked_workers_[i]) {
+          linked_workers_print +=  std::to_string(worker_id) + " ";
       }
-    }
-
-    CHECK_LT(factor_indices_to_remove_.count(worker_id_to_remove), 2u);
-    if (factor_indices_to_remove_.count(worker_id_to_remove) == 1u) {
-      factor_indices_to_remove.push_back(factor_indices_to_remove_.at(worker_id_to_remove));
-      factor_indices_to_remove_.erase(worker_id_to_remove);
-      worker_ids_with_removed_prior_.push_back(worker_id_to_remove);
-
-      // If we remove a prior use proper noise model.
-      new_factors_to_add = new_associations_factors;
-    }
   }
+  LOG(INFO) << "linked_workers before " << linked_workers_print;
+  
+  // No factor to remove if the ids are the same.
+  const unsigned int first_worker_id = affected_worker_ids.at(0u);
+  const unsigned int second_worker_id = affected_worker_ids.at(1u);
+  unsigned int worker_id_being_removed;
+  if (first_worker_id != second_worker_id) {
+      // Check whether the trajectories are already linked.
+      std::vector<std::vector<unsigned int> >::iterator it_first_worker_group, it_second_worker_group;
+      bool workers_are_already_linked = false;
+      for (std::vector<std::vector<unsigned int> >::iterator it = linked_workers_.begin();
+          it != linked_workers_.end(); ++it) {
+            bool first_worker_found = false;
+            bool second_worker_found = false;
+            if (std::find(it->begin(), it->end(), first_worker_id) != it->end()) {
+                it_first_worker_group = it;
+                first_worker_found = true;
+            }
+            if (std::find(it->begin(), it->end(), second_worker_id) != it->end()) {
+                it_second_worker_group = it;
+                second_worker_found = true;
+            }
+            if (first_worker_found && second_worker_found) {
+                workers_are_already_linked = true;
+            }
+      }
+
+      if (!workers_are_already_linked) {
+          // Check which group should be removed (if one contains ID 0 it should be kept). 
+          std::vector<std::vector<unsigned int> >::iterator it_group_to_keep, it_group_to_remove;
+          if (std::find(it_first_worker_group->begin(), it_first_worker_group->end(), 0u) 
+                    != it_first_worker_group->end()) {
+              it_group_to_keep = it_first_worker_group;
+              it_group_to_remove = it_second_worker_group;
+          } else {
+              it_group_to_keep = it_second_worker_group;
+              it_group_to_remove = it_first_worker_group;
+          }
+          // Find the factor id of the prior of the group to remove and link the groups.
+          for (const auto& worker_id : *it_group_to_remove) {
+              if (factor_indices_to_remove_.count(worker_id) == 1u) {
+                  factor_indices_to_remove.push_back(factor_indices_to_remove_.at(worker_id));
+                  factor_indices_to_remove_.erase(worker_id);
+                  worker_id_being_removed = worker_id;
+              }
+              it_group_to_keep->push_back(worker_id);
+              
+          }
+          CHECK_EQ(factor_indices_to_remove.size(), 1u);
+
+          // Erase the group to remove.
+          linked_workers_.erase(it_group_to_remove);
+      }
+  }
+  
+  if (!factor_indices_to_remove.empty()) {
+      LOG(INFO) << "Removing prior on worker id " << worker_id_being_removed;
+  }
+  
+  linked_workers_print = "";
+  for (size_t i = 0u; i < linked_workers_.size(); ++i) {
+      linked_workers_print += "Group " + std::to_string(i) + ": ";
+      for (const auto& worker_id : linked_workers_[i]) {
+          linked_workers_print +=  std::to_string(worker_id) + " ";
+      }
+  }
+  LOG(INFO) << "linked_workers after " << linked_workers_print;
 
   isam2_.update(new_factors_to_add, new_values, factor_indices_to_remove).print();
 
@@ -238,6 +271,10 @@ gtsam::Values IncrementalEstimator::registerPrior(const gtsam::NonlinearFactorGr
     factor_indices_to_remove_.insert(
         std::make_pair(worker_id, update_result.newFactorsIndices.at(0u)));
   }
+  std::vector<unsigned int> new_linked_worker;
+  new_linked_worker.push_back(worker_id);
+  linked_workers_.push_back(new_linked_worker);
+  
   // TODO Investigate why these two subsequent update calls are needed.
   isam2_.update();
   isam2_.update();

--- a/laser_slam/src/laser_track.cpp
+++ b/laser_slam/src/laser_track.cpp
@@ -143,10 +143,7 @@ void LaserTrack::processPoseAndLaserScan(const Pose& pose, const LaserScan& in_s
   LaserScan scan = in_scan;
 
   // Apply the input filters.
-  Clock clock;
   input_filters_.apply(scan.scan);
-  clock.takeTime();
-  LOG(INFO) << "Took " << clock.getRealTime() << " ms to filter the input scan.";
 
   // Save the pose measurement.
   if (pose_measurements_.empty() && pose.time_ns != 0) {
@@ -462,10 +459,7 @@ LaserTrack::makeMeasurementFactor(const Pose& pose_measurement,
 
 void LaserTrack::computeICPTransformations() {
   if (getNumScans() > 1u) {
-    Clock clock;
     localScanToSubMap();
-    clock.takeTime();
-    LOG(INFO) << "Took " << clock.getRealTime() << " ms to compute the ICP transformations.";
   }
 }
 
@@ -477,7 +471,6 @@ void LaserTrack::localScanToSubMap() {
 
   // Transform the last (parameters_.nscan_in_sub_map - 1) scans
   // in the frame of the second last scan.
-  Clock clock;
   const SE3 T_w_to_second_last_scan = trajectory_.evaluate(
       laser_scans_[getNumScans() - 2u].time_ns);
   DataPoints sub_map = laser_scans_[getNumScans() - 2u].scan;
@@ -491,8 +484,6 @@ void LaserTrack::localScanToSubMap() {
 
     sub_map.concatenate(rigid_transformation_->compute(previous_scan.scan,transformation_matrix));
   }
-  clock.takeTime();
-  LOG(INFO) << "Took " << clock.getRealTime() << " ms to build the submap.";
 
   // Obtain the initial guess from the trajectory.
   SE3 initial_guess = trajectory_.evaluate(icp_transformation.time_a_ns).inverse() *

--- a/laser_slam_ros/CMakeLists.txt
+++ b/laser_slam_ros/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(laser_slam_ros)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++11 -DBENCHMARK_ENABLE)
 
 find_package(catkin_simple 0.1.0 REQUIRED COMPONENTS
     roscpp

--- a/laser_slam_ros/include/laser_slam_ros/laser_slam_worker.hpp
+++ b/laser_slam_ros/include/laser_slam_ros/laser_slam_worker.hpp
@@ -69,9 +69,7 @@ class LaserSlamWorker {
 
   void setLockScanCallback(bool new_state);
 
-  void displayTimings() const;
-
-  void saveTimings() const;
+  void exportTrajectories() const;
 
   void exportTrajectoryHead(laser_slam::Time head_duration_ns, const std::string& filename) const;
 

--- a/laser_slam_ros/src/laser_slam_worker.cpp
+++ b/laser_slam_ros/src/laser_slam_worker.cpp
@@ -372,7 +372,7 @@ void LaserSlamWorker::publishMap() {
 void LaserSlamWorker::publishTrajectories() {
   Trajectory trajectory;
   laser_track_->getTrajectory(&trajectory);
-  publishTrajectory(trajectory, trajectory_pub_);
+  if (trajectory.size() > 0u) publishTrajectory(trajectory, trajectory_pub_);
 }
 
 // TODO can we move?

--- a/laser_slam_ros/src/laser_slam_worker.cpp
+++ b/laser_slam_ros/src/laser_slam_worker.cpp
@@ -190,7 +190,7 @@ void LaserSlamWorker::scanCallback(const sensor_msgs::PointCloud2& cloud_msg_in)
               matrix, params_.world_frame, params_.odom_frame, cloud_msg_in.header.stamp);
         }
 
-        // publishTrajectories();
+        publishTrajectories();
 
         // Get the last cloud in world frame.
         DataPoints new_fixed_cloud;

--- a/laser_slam_ros/src/laser_slam_worker.cpp
+++ b/laser_slam_ros/src/laser_slam_worker.cpp
@@ -397,10 +397,12 @@ void LaserSlamWorker::getFilteredMap(PointCloud* filtered_map) {
   {
     std::lock_guard<std::recursive_mutex> lock(local_map_mutex_);
     local_map = local_map_;
+    BENCHMARK_START("LS.getFilteredMap.firstApplyCylindricalFilter");
     applyCylindricalFilter(current_position, params_.distance_to_consider_fixed,
                            40, false, &local_map_);
+    BENCHMARK_STOP("LS.getFilteredMap.firstApplyCylindricalFilter");
   }
-
+BENCHMARK_START("LS.getFilteredMap.remaining1");
   // Apply a voxel filter.
   laser_slam::Clock clock;
 
@@ -434,7 +436,7 @@ void LaserSlamWorker::getFilteredMap(PointCloud* filtered_map) {
 
     applyCylindricalFilter(current_position, params_.distance_to_consider_fixed,
                            40, true, &new_distant_map);
-
+    BENCHMARK_STOP("LS.getFilteredMap.remaining1");
     {
       std::lock_guard<std::recursive_mutex> lock(local_map_filtered_mutex_);
       local_map_filtered_ = local_map_filtered;
@@ -540,8 +542,6 @@ void LaserSlamWorker::exportTrajectories() const {
 
 void LaserSlamWorker::exportTrajectoryHead(laser_slam::Time head_duration_ns,
                                            const std::string& filename) const {
-  BENCHMARK_BLOCK(LS_exportTrajectoryHead);
-
   Eigen::MatrixXd matrix;
   Trajectory traj;
   laser_track_->getTrajectory(&traj);

--- a/laser_slam_ros/src/laser_slam_worker.cpp
+++ b/laser_slam_ros/src/laser_slam_worker.cpp
@@ -425,12 +425,9 @@ void LaserSlamWorker::getFilteredMap(PointCloud* filtered_map) {
   {
     std::lock_guard<std::recursive_mutex> lock(local_map_mutex_);
     local_map = local_map_;
-    BENCHMARK_START("LS.getFilteredMap.firstApplyCylindricalFilter");
     applyCylindricalFilter(current_position, params_.distance_to_consider_fixed,
                            40, false, &local_map_);
-    BENCHMARK_STOP("LS.getFilteredMap.firstApplyCylindricalFilter");
   }
-BENCHMARK_START("LS.getFilteredMap.remaining1");
   // Apply a voxel filter.
   laser_slam::Clock clock;
 
@@ -464,7 +461,6 @@ BENCHMARK_START("LS.getFilteredMap.remaining1");
 
     applyCylindricalFilter(current_position, params_.distance_to_consider_fixed,
                            40, true, &new_distant_map);
-    BENCHMARK_STOP("LS.getFilteredMap.remaining1");
     {
       std::lock_guard<std::recursive_mutex> lock(local_map_filtered_mutex_);
       local_map_filtered_ = local_map_filtered;

--- a/laser_slam_ros/src/laser_slam_worker.cpp
+++ b/laser_slam_ros/src/laser_slam_worker.cpp
@@ -61,7 +61,7 @@ void LaserSlamWorker::init(
 
   // Setup services.
   get_laser_track_srv_ = nh.advertiseService(
-      params_.get_laser_track_srv_topic,
+      "get_laser_track",
       &LaserSlamWorker::getLaserTracksServiceCall, this);
   export_trajectory_srv_ = nh.advertiseService(
       "export_trajectory",

--- a/laser_slam_ros/src/laser_slam_worker.cpp
+++ b/laser_slam_ros/src/laser_slam_worker.cpp
@@ -190,7 +190,7 @@ void LaserSlamWorker::scanCallback(const sensor_msgs::PointCloud2& cloud_msg_in)
               matrix, params_.world_frame, params_.odom_frame, cloud_msg_in.header.stamp);
         }
 
-        publishTrajectories();
+        // publishTrajectories();
 
         // Get the last cloud in world frame.
         DataPoints new_fixed_cloud;
@@ -522,43 +522,10 @@ laser_slam::SE3 LaserSlamWorker::getTransformBetweenPoses(
   return last_pose * start_pose.inverse();
 }
 
-void LaserSlamWorker::displayTimings() const {
-  /*std::vector<double> scan_matching_times;
-  laser_track_->getScanMatchingTimes(&scan_matching_times);
-
-  double mean, sigma;
-  getMeanAndSigma(scan_matching_times, &mean, &sigma);
-  LOG(INFO) << "Scan matching times for worker id " << worker_id_ <<
-      ": " << mean << " +/- " << sigma;
-
-  std::vector<double> estimation_times;
-  incremental_estimator_->getEstimationTimes(&estimation_times);
-  getMeanAndSigma(estimation_times, &mean, &sigma);
-  LOG(INFO) << "Estimation times for worker id " << worker_id_ <<
-      ": " << mean << " +/- " << sigma;
-
-  incremental_estimator_->getEstimationAndRemoveTimes(&estimation_times);
-  getMeanAndSigma(estimation_times, &mean, &sigma);
-  LOG(INFO) << "Estimation and remove times for worker id " << worker_id_ <<
-      ": " << mean << " +/- " << sigma;
-
-   */
-}
-
-void LaserSlamWorker::saveTimings() const {
-  std::map<Time, double> scan_matching_times;
-  Eigen::MatrixXd matrix;
-  laser_track_->getScanMatchingTimes(&scan_matching_times);
-  toEigenMatrixXd(scan_matching_times, &matrix);
-  writeEigenMatrixXdCSV(matrix, "/tmp/timing_icp_" + std::to_string(worker_id_) + ".csv");
-
-  std::map<Time, double> estimation_times;
-  incremental_estimator_->getEstimationTimes(&estimation_times);
-  toEigenMatrixXd(estimation_times, &matrix);
-  writeEigenMatrixXdCSV(matrix, "/tmp/timing_estimation.csv");
-
+void LaserSlamWorker::exportTrajectories() const {
   Trajectory traj;
   laser_track_->getTrajectory(&traj);
+  Eigen::MatrixXd matrix;
   matrix.resize(traj.size(), 4);
   unsigned int i = 0u;
   for (const auto& pose : traj) {

--- a/laser_slam_tools/launch/map_to_world.launch
+++ b/laser_slam_tools/launch/map_to_world.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<launch>
+  
+  <node name="tf_publisher" pkg="tf" type="static_transform_publisher" args="0 0.0 0 0 0 0 1 map world 10"/>
+	
+</launch>

--- a/laser_slam_tools/src/laser_to_octomap.cpp
+++ b/laser_slam_tools/src/laser_to_octomap.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
 
   // Get laser track.
   ros::ServiceClient client;
-  client = nh.serviceClient<laser_slam_ros::GetLaserTrackSrv>("/laser_mapper/get_laser_track");
+  client = nh.serviceClient<laser_slam_ros::GetLaserTrackSrv>("/segmapper/get_laser_track");
   laser_slam_ros::GetLaserTrackSrv call;
   ROS_INFO("Requested laser track. Waiting...");
   if (!client.call(call)) {

--- a/laser_slam_tools/src/laser_to_octomap.cpp
+++ b/laser_slam_tools/src/laser_to_octomap.cpp
@@ -19,6 +19,7 @@ int main(int argc, char** argv) {
   double prob_hit = 0.9;
   double prob_miss = 0.4;
   double max_range = 20.0;
+  bool publish = true;
 
   // Parse arguments.
   if (argc > 2) {
@@ -99,6 +100,7 @@ int main(int argc, char** argv) {
     // Do insertion.
     manager.transformCallback(call.response.transforms[i]);
     manager.insertPointcloudWithTf(ptr_vec[i]);
+    if (publish) manager.publishAll();
   }
   std::cout << "\r" << std::flush;
   ROS_INFO("Done inserting all clouds");


### PR DESCRIPTION
Changed prior removing logic to handle more than 2 robots. Removed deprecated code for timing using the benchmarker instead.